### PR TITLE
[-] Target to create preprocessed source files

### DIFF
--- a/os/common/startup/ARMCMx/compilers/GCC/mk/rules.mk
+++ b/os/common/startup/ARMCMx/compilers/GCC/mk/rules.mk
@@ -283,6 +283,26 @@ clean: CLEAN_RULE_HOOK
 
 CLEAN_RULE_HOOK:
 
+## Target to output preprocessed source files
+PREPROC_DIR	:= $(BUILDDIR)/preproc
+PREPROC_OUT := $(addprefix $(PREPROC_DIR)/, $(notdir $(TCSRC:.c=.i)))
+
+$(PREPROC_OUT): | $(BUILDDIR) $(DEPDIR) $(PREPROC_DIR)
+
+$(PREPROC_DIR):
+	@mkdir -p $(PREPROC_DIR)
+
+$(PREPROC_OUT) : $(PREPROC_DIR)/%.i : %.c $(MAKEFILE_LIST)
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	@echo
+	$(CC) -E $(CFLAGS) -I. $(IINCDIR) $< -o $@
+else
+	@echo Creating $@
+	@$(CC) -E $(CFLAGS) -I. $(IINCDIR) $< -o $@
+endif
+
+preprocessor-out: $(PREPROC_OUT)
+
 #
 # Include the dependency files, should be the last of the makefile
 #


### PR DESCRIPTION
The make target _preprocessor-out_ creates preprocessor output files to build directory for manual inspection. It uses the same include directories and compiler flags as when building the target object files. These output files can be used to inspect the result of the preprocessor, for example how the defines have been resolved into valid code.

[WORK-4234]: https://stabl.atlassian.net/browse/WORK-4234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ